### PR TITLE
fix: Correct template path resolution

### DIFF
--- a/.changeset/thin-clocks-fail.md
+++ b/.changeset/thin-clocks-fail.md
@@ -1,0 +1,5 @@
+---
+"@t1mmen/srtd": patch
+---
+
+fix `register` template path resolution

--- a/src/utils/registerTemplate.ts
+++ b/src/utils/registerTemplate.ts
@@ -2,17 +2,15 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import chalk from 'chalk';
 import { calculateMD5 } from './calculateMD5.js';
-import { getConfig } from './config.js';
 import { fileExists } from './fileExists.js';
 import { loadBuildLog } from './loadBuildLog.js';
 import { saveBuildLog } from './saveBuildLog.js';
 
 export async function registerTemplate(templatePath: string, baseDir: string): Promise<void> {
-  const config = await getConfig(baseDir);
-
-  // Try multiple path resolutions
   const pathsToTry = [
-    path.join(baseDir, config.templateDir, templatePath), // In templates dir
+    path.resolve(templatePath),
+    path.resolve(baseDir, templatePath),
+    path.join(baseDir, templatePath)
   ];
 
   let resolvedPath: string | null = null;


### PR DESCRIPTION
### **User description**
Taking the lib for a spin, I noticed that it wasn't resolving the paths to my preexisting templates via the `register` command. It would come out like:
```
supabase/migrations-templates/Users/cn/Sites/cn/my-project/supabase/migrations-templates/checkout.sql
```
And looking at the input paths this seemed indeed an issue:
```
path.join(baseDir, config.templateDir, templatePath)
``` 
so `process.cwd()` would append the dir and then the path. 

Looking closer, by the time templatePath is input, its already been resolved here: https://github.com/t1mmen/srtd/blob/main/src/lib/templateManager.ts#L82

So this simplifies things and fixes the issue, allowing me to register my templates.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect template path resolution in `registerTemplate`.

- Removed redundant configuration-based path resolution logic.

- Simplified path resolution to use `path.resolve`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registerTemplate.ts</strong><dd><code>Simplify and fix template path resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/registerTemplate.ts

<li>Removed redundant <code>getConfig</code> import and usage.<br> <li> Simplified path resolution logic by removing unnecessary paths.<br> <li> Updated to use <code>path.resolve</code> for template path resolution.


</details>


  </td>
  <td><a href="https://github.com/t1mmen/srtd/pull/25/files#diff-0374114956b919afd5f2d282074e0576c66f5780fb29b7349c3141ff74af262a">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information